### PR TITLE
Fix #37 - Add a new condition to support Select value update

### DIFF
--- a/src/js/form-saver.js
+++ b/src/js/form-saver.js
@@ -287,6 +287,11 @@
 					if ( formSaverData[field.name + field.value] === 'on' ) {
 						field.checked = true;
 					}
+				} else if (field.type.toLowerCase() === 'select-one') {
+					if (field.value && field.value !== '') {
+						field.value = formSaverData[field.name];
+						field.dispatchEvent(new Event("change"));
+					}
 				} else if ( field.type.toLowerCase() !== 'hidden' && field.type.toLowerCase() !== 'submit' ) {
 					if ( formSaverData[field.name] ) {
 						field.value = formSaverData[field.name];


### PR DESCRIPTION
In the `populateField` function, add a new check to ensure we trigger the change event after changing a `Select` element value.

Here it only supports single selection drop-down, hence why checking for type `select-one`